### PR TITLE
Sender-Duplikate filtern

### DIFF
--- a/app/src/main/java/com/example/nzse_prak0/helpers/ChannelManager.java
+++ b/app/src/main/java/com/example/nzse_prak0/helpers/ChannelManager.java
@@ -32,15 +32,23 @@ public class ChannelManager {
 
     public void parseJSON(JSONObject json) throws JSONException {
         if (json.has("channels")) {              // Überprüfe ob "channels" vorhanden ist
+            List<String> occupiedPrograms = new ArrayList<>();
+
             channelList.clear();
             JSONArray channels = json.getJSONArray("channels");
             response = json.getString("status");
 
             for (int i = 0; i < channels.length(); i++) {
                 JSONObject channel = channels.getJSONObject(i);
-                Channel newChannel = new Channel(channel.getString(JSON_KEY_CHANNEL), channel.getString(JSON_KEY_PROGRAM), channel.getString(JSON_KEY_PROVIDER));
-                this.channelList.add(newChannel);
-                Log.d(newChannel.getProgram(), "Program");
+                String program = channel.getString(JSON_KEY_PROGRAM);
+                if (!occupiedPrograms.contains(program)) {
+                    Channel newChannel = new Channel(channel.getString(JSON_KEY_CHANNEL), program, channel.getString(JSON_KEY_PROVIDER));
+                    this.channelList.add(newChannel);
+                    Log.d(newChannel.getProgram(), "Program");
+                    occupiedPrograms.add(program);
+                } else {
+                    Log.d(program, "übersprungen, bereits vorhanden");
+                }
             }
         }
     }
@@ -52,10 +60,10 @@ public class ChannelManager {
             writer.beginArray();
             for (Channel c : channelList) {
                 writer.beginObject();
-                writer.name("channel").value(c.getChannel());
-                writer.name("program").value(c.getProgram());
-                writer.name("provider").value(c.getProvider());
-                writer.name("isFav").value(c.getIsFav());
+                writer.name(JSON_KEY_CHANNEL).value(c.getChannel());
+                writer.name(JSON_KEY_PROGRAM).value(c.getProgram());
+                writer.name(JSON_KEY_PROVIDER).value(c.getProvider());
+                writer.name(JSON_KEY_FAVORITE).value(c.getIsFav());
                 writer.endObject();
             }
             writer.endArray();

--- a/app/src/main/java/com/example/nzse_prak0/helpers/ChannelManager.java
+++ b/app/src/main/java/com/example/nzse_prak0/helpers/ChannelManager.java
@@ -25,6 +25,11 @@ public class ChannelManager {
     private String response;
     private ArrayList<Channel> channelList = new ArrayList<>();
 
+    private static final String JSON_KEY_CHANNEL = "channel";
+    private static final String JSON_KEY_PROGRAM = "program";
+    private static final String JSON_KEY_PROVIDER = "provider";
+    private static final String JSON_KEY_FAVORITE = "isFav";
+
     public void parseJSON(JSONObject json) throws JSONException {
         if (json.has("channels")) {              // Überprüfe ob "channels" vorhanden ist
             channelList.clear();
@@ -33,7 +38,7 @@ public class ChannelManager {
 
             for (int i = 0; i < channels.length(); i++) {
                 JSONObject channel = channels.getJSONObject(i);
-                Channel newChannel = new Channel(channel.getString("channel"), channel.getString("program"), channel.getString("provider"));
+                Channel newChannel = new Channel(channel.getString(JSON_KEY_CHANNEL), channel.getString(JSON_KEY_PROGRAM), channel.getString(JSON_KEY_PROVIDER));
                 this.channelList.add(newChannel);
                 Log.d(newChannel.getProgram(), "Program");
             }
@@ -77,16 +82,16 @@ public class ChannelManager {
                 while (reader.hasNext()) {
                     String name = reader.nextName();
                     switch(name) {
-                        case "channel":
+                        case JSON_KEY_CHANNEL:
                             channel = reader.nextString();
                             break;
-                        case "program":
+                        case JSON_KEY_PROGRAM:
                             program = reader.nextString();
                             break;
-                        case "provider":
+                        case JSON_KEY_PROVIDER:
                             provider = reader.nextString();
                             break;
-                        case "isFav":
+                        case JSON_KEY_FAVORITE:
                             isFav = reader.nextBoolean();
                             break;
                         default:


### PR DESCRIPTION
Bei der JSON-Response von scanChannels gibt es Duplikate, die zum gleichen Sender gehören, aber unterschiedliche Frequenzen belegen.
Da dieser Simulator nur die Channel-ID und keine Frequenz benötigt, können diese Duplikate übersprungen werden.